### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.snake-game-backend
+++ b/Dockerfile.snake-game-backend
@@ -1,0 +1,26 @@
+FROM node:16-alpine
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+EXPOSE 3001
+
+ENV DB_HOST=localhost
+ENV DB_PORT=27017
+ENV DB_NAME=snakeGame
+ENV DB_USER=user
+ENV DB_PASS=password
+
+CMD [ "node", "index.js" ]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO snake-game
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,93 @@
+namespace: snake-game
+
+mongodb:
+  defines: runnable
+  inherits: mongodb/mongodb
+  metadata:
+    name: mongodb
+    description: >-
+      MongoDB database service required by the Node.js backend to store high
+      scores.
+    icon: >-
+      https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRA8VbFgxH-i78AZmNqD93mVRkTRd30POqLeCmg9T05ug&s
+  variables:
+    mongo-image:
+      type: string
+      value: latest
+      description: ''
+    mongo-init-database:
+      type: string
+      value: mongo
+      description: ''
+    mongo-init-password:
+      type: string
+      value: password
+      description: ''
+    mongo-init-username:
+      type: string
+      value: mongo
+      description: ''
+    mongodb-image:
+      type: string
+      value: latest
+      description: ''
+
+snake-game-backend:
+  defines: runnable
+  metadata:
+    name: snake-game-backend
+    description: >-
+      Node.js backend service for the snake game, serving static files and
+      handling high scores with MongoDB.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    snake-game-backend:
+      image: env-2205.registry.local/snake-game-backend:main-de90c06
+      build: .
+      dockerfile: Dockerfile.snake-game-backend
+  services:
+    http-server-port:
+      description: Port for HTTP server to serve static files and handle API requests
+      container: snake-game-backend
+      port: 3001
+      host-port: 3001
+      publish: true
+      protocol: tcp
+  connections:
+    mongodb-connection:
+      target: snake-game/mongodb
+      service: mongodb
+      optional: true
+      description: Connection to the MongoDB service for high scores storage
+  variables:
+    db-host:
+      env: DB_HOST
+      type: string
+      value: <- connection-hostname("mongodb-connection")
+      description: Hostname for the MongoDB database
+    db-port:
+      env: DB_PORT
+      type: int
+      value: <- connection-port("mongodb-connection")
+      description: Port for the MongoDB database
+    db-name:
+      env: DB_NAME
+      type: string
+      value: snakeGame
+      description: Database name for the MongoDB database
+    db-user:
+      env: DB_USER
+      type: string
+      value: user
+      description: Username for the MongoDB database
+    db-pass:
+      env: DB_PASS
+      type: string
+      value: password
+      description: Password for the MongoDB database
+
+stack:
+  defines: group
+  members:
+    - snake-game/mongodb
+    - snake-game/snake-game-backend


### PR DESCRIPTION
# Containerization and Deployment Configuration for Snake-Game

## Changes Made

- **Dockerfile Creation**: I've created a `Dockerfile.snake-game-backend` to containerize the Node.js backend of the snake game. This Dockerfile sets up the Node.js environment, installs necessary dependencies such as Fastify and Mongoose, and starts the application using `node index.js`.
  
- **Monk.io Configuration**: A `monk.yaml` file has been added to define the deployment configuration for Monk.io. This includes the setup for the Node.js application and the MongoDB service. The `MANIFEST` file has also been added to list all files containing Monk configurations.

- **Service Mapping**: The application has been confirmed to use MongoDB as its database, with no other third-party services required. The MongoDB connection string is constructed from environment variables, and the application serves static files from the 'public/cobra' directory.

- **Environment Variables**: The Dockerfile for `snake-game-backend` includes environment variables `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, and `DB_PASS` with default values, which are used by the application to connect to MongoDB.

## Instructions for Continuation

- **Merge PR**: The PR can be merged, and the application will be re-deployed on each subsequent push. The backend service is set to connect to MongoDB, which should be running in the environment for the application to function properly.

- **Database Connection**: Ensure that the MongoDB service is available and correctly configured in the environment where the Node.js application is deployed. The application expects the database to be accessible using the environment variables specified in the Dockerfile.

## Notes

- The backend service is designed to connect to a MongoDB instance. During isolated testing, a connection error (`connect ECONNREFUSED 127.0.0.1:27017`) was observed, which is expected since the MongoDB service was not running. This error will resolve once the service is deployed with access to a MongoDB instance.

- The application exposes port 3001, which should be taken into account when configuring network settings for deployment.

By merging this PR, the snake-game application will be containerized and ready for deployment using Monk.io, with the backend service configured to connect to a MongoDB database.