### PR TITLE
Monk: Add Monk Kit on demo branch

### DIFF
--- a/Dockerfile.snake-game-backend
+++ b/Dockerfile.snake-game-backend
@@ -1,0 +1,26 @@
+FROM node:14
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+# Environment variables
+ENV MONGODB_URI=
+ENV DB_USER=
+ENV DB_PASS=
+
+# Your app binds to port 3000 so you'll use the EXPOSE instruction to have it mapped by the docker daemon
+EXPOSE 3000
+
+CMD [ "node", "index.js" ]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO snake-game
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,99 @@
+namespace: snake-game
+
+mongodb:
+  defines: runnable
+  inherits: mongodb/mongodb
+  metadata:
+    name: mongodb
+    description: MongoDB database service for storing high-scores.
+    icon: >-
+      https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRA8VbFgxH-i78AZmNqD93mVRkTRd30POqLeCmg9T05ug&s
+  variables:
+    mongo-image:
+      type: string
+      value: latest
+      description: ''
+    mongo-init-database:
+      type: string
+      value: mongo
+      description: ''
+    mongo-init-password:
+      type: string
+      value: password
+      description: ''
+    mongo-init-username:
+      type: string
+      value: mongo
+      description: ''
+    mongodb-image:
+      type: string
+      value: latest
+      description: ''
+
+snake-game-backend:
+  defines: runnable
+  metadata:
+    name: snake-game-backend
+    description: >-
+      The backend service for the snake game, handling game logic and high-score
+      persistence.
+    icon: https://emojiapi.dev/api/v1/video_game.svg
+  containers:
+    snake-game-backend:
+      image: env-4633.registry.local/snake-game-backend:demo-qx4cet
+      build: .
+      dockerfile: Dockerfile.snake-game-backend
+  services:
+    fastify-http:
+      description: HTTP server listening port for the snake-game-backend service.
+      container: snake-game-backend
+      port: 3001
+      host-port: 3001
+      publish: true
+      protocol: tcp
+  connections:
+    database-connection:
+      target: snake-game/mongodb
+      service: mongodb
+      optional: true
+      description: >-
+        Connection from snake-game-backend to MongoDB service for high-score
+        persistence.
+  variables:
+    db-host:
+      env: DB_HOST
+      type: string
+      value: <- connection-hostname("database-connection")
+      description: The hostname of the database server.
+    db-port:
+      env: DB_PORT
+      type: int
+      value: <- connection-port("database-connection")
+      description: The port number on which the database server is running.
+    db-name:
+      env: DB_NAME
+      type: string
+      value: mongo
+      description: The name of the database to connect to.
+    db-user:
+      env: DB_USER
+      type: string
+      value: mongo
+      description: The username for the database connection.
+    db-pass:
+      env: DB_PASS
+      type: string
+      value: password
+      description: The password for the database connection.
+
+stack:
+  defines: group
+  members:
+    - snake-game/mongodb
+    - snake-game/snake-game-backend
+  metadata:
+    name: snake-game
+    description: >-
+      A simple snake game with a persistent high-score chart, built with Node.js
+      and Fastify.
+    icon: https://emojiapi.dev/api/v1/snake.svg


### PR DESCRIPTION
# Containerization and Deployment Configuration for Snake-Game

## Summary of Changes

I've successfully containerized the `snake-game` backend and prepared the deployment configuration using Monk.io. Below are the key changes and additions:

- **Dockerfile**: Created `Dockerfile.snake-game-backend` to build the Node.js application container. This Dockerfile sets up the environment, installs dependencies, and configures the necessary environment variables and exposed ports.
- **Monk.io Configuration**: Added `monk.yaml` and `MANIFEST` to define the Monk.io deployment configuration. This includes service definitions, environment variables, and connections for the `snake-game-backend` service.
- **Service Mapping**: Confirmed the application requires a MongoDB service and no additional third-party services. The backend connects to MongoDB using environment variables for the connection string.

## Configuration Details

- **Environment Variables**: Identified and configured the environment variables `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, and `DB_PASS` for the `snake-game-backend` service. These are crucial for the MongoDB connection.
- **Ports**: Updated the service to listen on port `3001` as specified in the `index.js` file. The service will listen on all network interfaces (`0.0.0.0`).
- **Service Connections**: Established a connection between the `snake-game-backend` service and the MongoDB service. Set the `snake-game-backend` variables `db-name`, `db-user`, and `db-pass` to match the MongoDB service credentials.

## Instructions for Continuation

The PR is ready to be merged. Upon merging, the application will be re-deployed on each subsequent push. Ensure that the environment variables for MongoDB are correctly set in the deployment environment to allow for successful connections.

If any further adjustments are needed, particularly regarding environment variables or connections, please refer to the `monk.yaml` and `Dockerfile.snake-game-backend` for the necessary changes.